### PR TITLE
fix(campaign-listing) Attachments is not a mandatory field

### DIFF
--- a/site/web/app/lib/Entity/Campaign.php
+++ b/site/web/app/lib/Entity/Campaign.php
@@ -43,7 +43,7 @@ class Campaign extends Entity {
     return $this->attachments;
   }
 
-  public function setAttachments(array $attachments): Campaign {
+  public function setAttachments(?array $attachments): Campaign {
     $this->attachments = $attachments;
     return $this;
   }

--- a/site/web/app/lib/Repository/AbstractRepository.php
+++ b/site/web/app/lib/Repository/AbstractRepository.php
@@ -62,6 +62,14 @@ abstract class AbstractRepository {
         return static::getEntity($post);
     }
 
+    protected static function falseyToNull($value) {
+      if ($value === false) {
+        return null;
+      }
+
+      return $value;
+    }
+
     abstract protected static function getEntity(
       \WP_Post $post,
       bool $includeRelated = false

--- a/site/web/app/lib/Repository/CampaignRepository.php
+++ b/site/web/app/lib/Repository/CampaignRepository.php
@@ -17,6 +17,8 @@ final class CampaignRepository extends AbstractRepository {
       ->setPermalink(get_the_permalink())
       ->setImage(get_field('imagine'))
       ->setExtras(get_field('extras'))
-      ->setAttachments(get_field('materiale_de_informare'));
+      ->setAttachments(static::falseyToNull(
+        get_field('materiale_de_informare')
+      ));
   }
 }

--- a/site/web/app/lib/Repository/GuideRepository.php
+++ b/site/web/app/lib/Repository/GuideRepository.php
@@ -18,10 +18,10 @@ final class GuideRepository extends AbstractRepository {
       ->setDupaEveniment(get_field('dupa_eveniment'))
       ->setInformatiiAditionale(get_field('informatii_aditionale'))
       ->setVideoAjutator(get_field('video_ajutator'))
-      ->setGalerieFoto(self::falseyToNull(
+      ->setGalerieFoto(static::falseyToNull(
         get_field('galerie_foto')
       ))
-      ->setGuidePDF(self::falseyToNull(
+      ->setGuidePDF(static::falseyToNull(
         get_field('ghid_pdf')
       ))
       ->setPictograma(get_field('pictograma_eveniment'))
@@ -32,14 +32,6 @@ final class GuideRepository extends AbstractRepository {
     }
 
     return $ghid;
-  }
-
-  private static function falseyToNull($value) {
-    if ($value === false) {
-      return null;
-    }
-
-    return $value;
   }
 
   private static function getSimilarGuides(): array {

--- a/site/web/app/themes/sage/home.php
+++ b/site/web/app/themes/sage/home.php
@@ -104,7 +104,7 @@
   $campaignProps = array();
   foreach ($campaigns as $campaign) {
     $campaignProps[] = array(
-      'image' => $campaign->getImage()->getUrl(),
+      'image' => $campaign->getImage(),
       'title' => $campaign->getTitle(),
       'permalink' => $campaign->getPermalink(),
       'extras' => $campaign->getExtras(),

--- a/site/web/app/themes/sage/templates/listing-campanii.php
+++ b/site/web/app/themes/sage/templates/listing-campanii.php
@@ -8,7 +8,7 @@ $campaigns = \RepoManager::getCampaignRepository()->getList();
 $campaignProps = array();
 foreach ($campaigns as $campaign) {
   $campaignProps[] = array(
-    'image' => $campaign->getImage()->getUrl(),
+    'image' => $campaign->getImage(),
     'title' => $campaign->getTitle(),
     'permalink' => $campaign->getPermalink(),
     'extras' => $campaign->getExtras(),

--- a/site/web/app/themes/sage/templates/mustache/campaign_listing.mustache
+++ b/site/web/app/themes/sage/templates/mustache/campaign_listing.mustache
@@ -14,7 +14,7 @@
             </div>
             <div
               class="d-block mx-auto mt-3 mb-3 border campaign-photo"
-              style="background-image: url({{ image }})">
+              style="background-image: url({{ image.url }})">
             </div>
             <div class="campaign-extras">
               {{ extras }}


### PR DESCRIPTION
#### Rezumat al schimbărilor:
`get_field` returns `false` instead of `null` for no value, so coerce
`false` to `null` in the repository.

Also, since `Mustache` works with arrays, not with objects, pass an
array rather than the object to the template.

#### Test plan:
Went through every page, listing renders correctly

