### PR TITLE
fix(campaign) Show attachments only when attachments available

### DIFF
--- a/site/web/app/themes/sage/assets/styles/common/_global.scss
+++ b/site/web/app/themes/sage/assets/styles/common/_global.scss
@@ -582,6 +582,7 @@ h2:after {
   font-weight: bold;
   border: 0;
   text-transform: uppercase;
+  padding-left: 0;
 }
 
 #campaign-content .campaign-info:focus {

--- a/site/web/app/themes/sage/templates/content-single-campanie.php
+++ b/site/web/app/themes/sage/templates/content-single-campanie.php
@@ -20,11 +20,8 @@
       'title' => $campaign->getTitle(),
       'image' => $campaign->getImage(),
       'content' => $campaign->getContent(),
-      'has_attachments' => true, //(bool) $campaign->getAttachments(),
+      'has_attachments' => (bool) $campaign->getAttachments(),
       'attachments' => array(
-        array(
-          'attachment' => $campaign->getAttachments(),
-        ),
         array(
           'attachment' => $campaign->getAttachments(),
         )


### PR DESCRIPTION
#### Rezumat al schimbărilor:
- Afișează buton materiale de informare doar atunci când există
- Scoate extra padding-ul stânga
 
#### Test plan:
👀 

#### Closes #101, #102 
