### PR TITLE
fix(guides) Don't use event name in card headers on guide page

### DIFF
--- a/site/web/app/themes/sage/templates/mustache/guide.mustache
+++ b/site/web/app/themes/sage/templates/mustache/guide.mustache
@@ -31,7 +31,7 @@
                   data-target="#collapseOne"
                   aria-expanded="true"
                   aria-controls="collapseOne">
-                  Înainte de {{ title }}
+                  Înainte de eveniment
                   <i class="fa fa-chevron-down pull-right"></i>
                 </button>
               </h5>
@@ -55,7 +55,7 @@
                   data-target="#collapseTwo"
                   aria-expanded="false"
                   aria-controls="collapseTwo">
-                  În timpul {{ title }}
+                  În timpul evenimentului
                   <i class="fa fa-chevron-down pull-right"></i>
                 </button>
               </h5>
@@ -79,7 +79,7 @@
                   data-target="#collapseThree"
                   aria-expanded="false"
                   aria-controls="collapseThree">
-                  După {{ title }}
+                  După eveniment
                   <i class="fa fa-chevron-down pull-right"></i>
                 </button>
               </h5>


### PR DESCRIPTION
#### Rezumat al schimbărilor:
`s/{{title}}/eveniment(ului)` cum a sugerat Radu
#### Test plan:
👀 
#### Fixes #72 
