### PR TITLE
fix(mobile) Hide social icons from the nav on mobile

### DIFF
--- a/site/web/app/themes/sage/templates/header.php
+++ b/site/web/app/themes/sage/templates/header.php
@@ -31,7 +31,7 @@
   </button>
 
 	<div id="navbarContent" class="collapse navbar-collapse">
-		<ul class="social-menu">
+		<ul class="social-menu d-none d-lg-block"> 
 			<li class="first">
 				<a href="https://www.facebook.com/departamenturgente">
 					<i class="fab fa-facebook-square"></i>


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Scos social icons din navigatie pe ecrane mici (acolo unde avem hamburger menu)
#### Test plan:
👀 
#### Fixes #169 
