### PR TITLE
fix(mobile) Keep hamburger menu on the right side even on tiny screens

### DIFF
--- a/site/web/app/themes/sage/assets/styles/layouts/_header.scss
+++ b/site/web/app/themes/sage/assets/styles/layouts/_header.scss
@@ -19,11 +19,11 @@
   .navbar-brand {
     min-width: 450px;
   }
-} 
+}
 
 @include media-breakpoint-down(sm) {
   .navbar-brand {
-    max-width: 275px;
+    max-width: 260px;
   }
 }
 


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Nu colapsa hamburger menu sub logo pe ecrane mici
#### Test plan:
👀 
#### Fixes #168
