### PR TITLE
feat(dash) Generate dashboard guides from `.md` files

### DIFF
--- a/site/web/app/themes/sage/composer.json
+++ b/site/web/app/themes/sage/composer.json
@@ -26,6 +26,8 @@
   "require": {
     "php": ">=5.6.3",
     "composer/installers": "~1.0",
-    "mustache/mustache": "2.12.0"
+    "mustache/mustache": "2.12.0",
+    "erusev/parsedown": "1.6.4",
+    "ezyang/htmlpurifier": "4.9.3"
   }
 }

--- a/site/web/app/themes/sage/composer.lock
+++ b/site/web/app/themes/sage/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "04937d5ab39e908e0b6148444ea6f69a",
-    "content-hash": "c977499bd714109cf8c38b2ccd9f93c5",
+    "content-hash": "98b357d673a81c709dc298846452d4bd",
     "packages": [
         {
             "name": "composer/installers",
@@ -125,7 +124,99 @@
                 "zend",
                 "zikula"
             ],
-            "time": "2017-12-29 09:13:20"
+            "time": "2017-12-29T09:13:20+00:00"
+        },
+        {
+            "name": "erusev/parsedown",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/erusev/parsedown.git",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "reference": "fbe3fe878f4fe69048bb8a52783a09802004f548",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Parsedown": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Emanuil Rusev",
+                    "email": "hello@erusev.com",
+                    "homepage": "http://erusev.com"
+                }
+            ],
+            "description": "Parser for Markdown.",
+            "homepage": "http://parsedown.org",
+            "keywords": [
+                "markdown",
+                "parser"
+            ],
+            "time": "2017-11-14T20:44:03+00:00"
+        },
+        {
+            "name": "ezyang/htmlpurifier",
+            "version": "v4.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ezyang/htmlpurifier.git",
+                "reference": "95e1bae3182efc0f3422896a3236e991049dac69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/95e1bae3182efc0f3422896a3236e991049dac69",
+                "reference": "95e1bae3182efc0f3422896a3236e991049dac69",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "simpletest/simpletest": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "HTMLPurifier": "library/"
+                },
+                "files": [
+                    "library/HTMLPurifier.composer.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL"
+            ],
+            "authors": [
+                {
+                    "name": "Edward Z. Yang",
+                    "email": "admin@htmlpurifier.org",
+                    "homepage": "http://ezyang.com"
+                }
+            ],
+            "description": "Standards compliant HTML filter written in PHP",
+            "homepage": "http://htmlpurifier.org/",
+            "keywords": [
+                "html"
+            ],
+            "time": "2017-06-03T02:28:16+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -171,7 +262,7 @@
                 "mustache",
                 "templating"
             ],
-            "time": "2017-07-11 12:54:05"
+            "time": "2017-07-11T12:54:05+00:00"
         }
     ],
     "packages-dev": [],

--- a/site/web/app/themes/sage/functions.php
+++ b/site/web/app/themes/sage/functions.php
@@ -22,6 +22,7 @@ $sage_includes = [
   'lib/wrapper.php',   // Theme wrapper class
   'lib/customizer.php', // Theme customizer
   'lib/TemplateEngine.php',
+  'lib/DashboardGuides.php',
   'lib/Algolia/IndexCustomFields.php',
   'lib/Algolia/GuideIndexCustomFields.php',
   'lib/Algolia/CampaignIndexCustomFields.php',
@@ -64,10 +65,18 @@ function remove_dashboard_widgets() {
   unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_drafts']);
   unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_primary']);
   unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_secondary']);
+  unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_incoming_links']);
+  unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_comments']);
+  unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_activity']);
 }
-if (!current_user_can('manage_options')) {
-  add_action('wp_dashboard_setup', 'remove_dashboard_widgets' );
-}
+
+add_action('wp_dashboard_setup', 'remove_dashboard_widgets' );
+
+$dashboardCallback = function() {
+  return DashboardGuides::get()->render();
+};
+
+add_action('wp_dashboard_setup', $dashboardCallback);
 
 /**
  * Scoate meniurile din sidebar pentru toată lumea în afară de admini

--- a/site/web/app/themes/sage/lib/DashboardGuides.php
+++ b/site/web/app/themes/sage/lib/DashboardGuides.php
@@ -1,0 +1,51 @@
+<?php
+
+  final class DashboardGuides {
+    private static $instance = null;
+    private $guidePath = null;
+    private $parser = null;
+    private $purifier = null;
+
+    private function __construct() {
+      $this->guidePath = dirname(__FILE__).'/../templates/markdown/';
+      $this->parser = new Parsedown();
+      $this->purifier = new HTMLPurifier(HTMLPurifier_Config::createDefault());
+    }
+
+    public static function get(): DashboardGuides {
+      if (self::$instance) {
+        return $instance;
+      }
+
+      return new DashboardGuides();
+    }
+
+    public function render(): void {
+      $handler = opendir($this->guidePath);
+
+      while (($file = readdir($handler)) !== false) {
+        $file_path = $this->guidePath . $file;
+        if (!is_file($file_path)) {
+          continue;
+        }
+
+        $path_parts = pathinfo($file);
+        if ($path_parts['extension'] !== 'md') {
+          continue;
+        }
+
+        $contents = file_get_contents($this->guidePath . $file);
+        $output = $this->purifier->purify(
+          $this->parser->text($contents)
+        );
+
+        wp_add_dashboard_widget(
+          'help_widget_'.$path_parts['filename'],
+          $path_parts['filename'],
+          function() use ($output) {
+            echo $output;
+          }
+        );
+      }
+    }
+  }

--- a/site/web/app/themes/sage/templates/markdown/Adaugă ghid.md
+++ b/site/web/app/themes/sage/templates/markdown/Adaugă ghid.md
@@ -1,0 +1,1 @@
+It's very easy to make some words **bold** and other words *italic* with Markdown. You can even [link to Google!](http://google.com)

--- a/site/web/app/themes/sage/templates/markdown/Contact CivicTech România.md
+++ b/site/web/app/themes/sage/templates/markdown/Contact CivicTech România.md
@@ -1,0 +1,1 @@
+[civictech.ro](https://civictech.ro)


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Adaugat un sistem de generare de ghiduri pentru editorii de continut. Toate fisierele `.md` din `sage/templates/markdown` sunt parsate si afisate in dashboard sub forma de widget. 

Mai multe info in #148 

#### Test plan:
![awesomescreenshot-2018-02-13t17-04-01-773z](https://user-images.githubusercontent.com/22706412/36163113-09582614-10f1-11e8-8a53-8b55eb468a97.gif)
