### PR TITLE
fix(dash) Make images max 100% wide in dashboard

### DIFF
--- a/site/web/app/themes/sage/lib/DashboardGuides.php
+++ b/site/web/app/themes/sage/lib/DashboardGuides.php
@@ -23,6 +23,14 @@
     public function render(): void {
       $handler = opendir($this->guidePath);
 
+      $custom_css = $this->customCSS();
+      add_action(
+        'admin_head',
+        function() use ($custom_css) {
+          echo $custom_css;
+        }
+      );
+
       while (($file = readdir($handler)) !== false) {
         $file_path = $this->guidePath . $file;
         if (!is_file($file_path)) {
@@ -35,9 +43,11 @@
         }
 
         $contents = file_get_contents($this->guidePath . $file);
-        $output = $this->purifier->purify(
-          $this->parser->text($contents)
-        );
+        $output = '<div class="dash-guides">' .
+          $this->purifier->purify(
+            $this->parser->text($contents)
+          )
+        . '</div>';
 
         wp_add_dashboard_widget(
           'help_widget_'.$path_parts['filename'],
@@ -47,5 +57,14 @@
           }
         );
       }
+    }
+
+    private function customCSS(): string {
+      return
+        '<style>
+          .dash-guides img {
+            max-width: 100%;
+          }
+        </style>';
     }
   }

--- a/site/web/app/themes/sage/templates/markdown/Adaugă ghid.md
+++ b/site/web/app/themes/sage/templates/markdown/Adaugă ghid.md
@@ -1,6 +1,6 @@
 ![Adăugare ghid](https://fiipregatit.ro/app/uploads/2018/02/Ghiduri-‹-fiipregătit-ro-—-WordPress.png)
 
-Selectați din sidebar-ul din partea stângă opțiunea `Ghiduri`, apoi `Add new`. 
+Selectați din sidebar-ul din partea stângă opțiunea `Ghiduri`, apoi `Add new`.
 
 În pagina de adăugare ghid nou, avem o listă de opțiuni pe care le putem completa. Cele marcate cu asterisc sunt obligatorii:
 
@@ -14,7 +14,7 @@ Este important ca acesta să fie strict numele evenimentului (ex: cutremur, vije
 
 ## Pregătire înainte, după și în timpul evenimentului
 
-Cele trei câmpuri pentru detalierea pașilor ce trebuie făcuți înainte, după și în timpul evenimentului oferă opțiunea de formatare a textului prin toolbar-ul de deasupra câmpului: 
+Cele trei câmpuri pentru detalierea pașilor ce trebuie făcuți înainte, după și în timpul evenimentului oferă opțiunea de formatare a textului prin toolbar-ul de deasupra câmpului:
 
 ![Toolbar](https://fiipregatit.ro/app/uploads/2018/02/toolbar.png)
 
@@ -24,7 +24,7 @@ Dintre opțiunile prezentate în toolbar, cea mai proeminentă este cea de list�
 
 ## Informații adiționale
 
-Dacă se dorește adăugarea de conținut text despre tipul de eveniment introdus, dar fără legătură cu recomandările legate de acesta, se poate folosi câmpul "Informații adiționale". 
+Dacă se dorește adăugarea de conținut text despre tipul de eveniment introdus, dar fără legătură cu recomandările legate de acesta, se poate folosi câmpul "Informații adiționale".
 
 ## Video ajutător
 


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Nu lasa latimea imaginilor sa depaseasca latimea coloanei parinte

#### Test plan:
![dashboard dev fiipregatit ro wordpress](https://user-images.githubusercontent.com/22706412/36168080-961d3026-1100-11e8-9f2a-88b9918240de.png)

