### PR TITLE
fix(contact) Better contact form with Pirate Forms

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -50,7 +50,8 @@
     "wpackagist-plugin/simple-custom-post-order": "2.3.2",
     "wpackagist-plugin/simple-page-ordering": "2.2.4",
     "wpackagist-plugin/search-by-algolia-instant-relevant-results": "2.9.3",
-    "wpackagist-plugin/cmb2": "2.3.0"
+    "wpackagist-plugin/cmb2": "2.3.0",
+    "wpackagist-plugin/pirate-forms": "2.3.3"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^2.5.1"

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7bcef49e5df6cffac3a4a1632ed11242",
+    "content-hash": "f928e9b889c07d1376ae1c8b24a2e645",
     "packages": [
         {
             "name": "composer/installers",
@@ -429,6 +429,26 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/cmb2/"
+        },
+        {
+            "name": "wpackagist-plugin/pirate-forms",
+            "version": "2.3.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/pirate-forms/",
+                "reference": "tags/2.3.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/pirate-forms.2.3.3.zip",
+                "reference": null,
+                "shasum": null
+            },
+            "require": {
+                "composer/installers": "~1.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/pirate-forms/"
         },
         {
             "name": "wpackagist-plugin/search-by-algolia-instant-relevant-results",

--- a/site/web/app/themes/sage/templates/contact.php
+++ b/site/web/app/themes/sage/templates/contact.php
@@ -181,5 +181,6 @@ TemplateEngine::get()->render(
     'recaptcha_api_key' => '6LfB7UQUAAAAAMIBIqEI1sEy5o3Igjn6i7fC22c1',
     'location' => 'Piața Revoluției, nr.1 A, sector 1, București',
     'style' => $custom_style,
+    'contact_form' => do_shortcode('[pirate_forms]'), 
   )
 );

--- a/site/web/app/themes/sage/templates/mustache/contact.mustache
+++ b/site/web/app/themes/sage/templates/mustache/contact.mustache
@@ -18,53 +18,7 @@
         </div>
       </div>
       <div class="col col-md-6 col-sm-12">
-        <form role="form">
-  				<div class="form-group">
-  				  <input
-              type="text"
-              class="form-control"
-              id="name"
-              name="name"
-              placeholder="Nume și Prenume"
-              required>
-  				</div>
-  				<div class="form-group">
-  					<input
-              type="text"
-              class="form-control"
-              id="email"
-              name="email"
-              placeholder="Email"
-              required>
-  				</div>
-  				<div class="form-group">
-  					<input
-              type="text"
-              class="form-control"
-              id="subject"
-              name="subject"
-              placeholder="Subiect"
-              required>
-  				</div>
-          <div class="form-group">
-            <textarea
-              class="form-control"
-              type="textarea"
-              id="message"
-              placeholder="Mesaj"
-              maxlength="512"
-              rows="7"></textarea>
-          </div>
-          <div class="g-recaptcha" data-sitekey="{{ recaptcha_api_key }}"></div>
-          <button
-            type="button"
-            id="submit"
-            name="submit"
-            class="btn btn-primary all-button">
-            Trimite
-            <i class="far fa-check-circle"></i>
-          </button>
-        </form>
+        {{{ contact_form }}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Adaugat Pirate Forms pentru contact. Worst case scenario, daca mail-urile ajung in junk, macar se salveaza o copie in admin panel. 

Ofera si integrare cu recaptcha which is a plus.
#### Test plan:
Mers pe pagina de contact si trimis un mail, validat ca se salveaza in admin. Nu am testat integrarea SMTP pentru ca nu avem inca credentiale - vom testa in prod.
#### Fixes #143 
