### PR TITLE
fix(devex) Make all plugins must-use plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Open `http://dev.fiipregatit.ro/admin`. Use the admin password you just set in `
 Once logged in, it's time to config a few things in the admin panel:
 
 - Go to `Appearance->Themes` and enable **fiipregătit.ro**, our custom theme
-- Navigate to `Plugins->Installed Plugins` and enable `Advanced Custom Fields`
-- Now that we have custom fields enabled, we need to import our data structures. Go to `Custom Fields->Tools`, and upload `fiipregatit.ro/site/config/misc/acf-export-yyyy-mm-dd.json` using the `Import Field Groups` panel.
+- Go to `Custom Fields->Tools`, and upload `fiipregatit.ro/site/config/misc/acf-export-yyyy-mm-dd.json` using the `Import Field Groups` panel.
 - The navigation is not enabled by default. To add the main navigation go to `Appearance->Customize->Menus->Main Navigation` and create the menu. Make sure you check the `Main Navigation` menu location here. Publish when you're done.
 - Lastly, it's time to import some scaffolding data. Navigate to `Tools->Import` and select `Run Importer` for the WordPress option (last one). Now import  `fiipregatit.ro/site/config/misc/fiipregtitro.wordpress.yyyy-mm-dd.xml`
 
@@ -93,11 +92,9 @@ on search, there's no need for you to read further. If you are:
 
 - You need to create an account on Algolia. They offer a free plan, that should be
 more than enough for development purposes.
-- Activate the Algolia plugin in the admin panel.
-- Once activated:
-  - Go to `Algolia->Settings`: Add the API keys from your [Algolia app dashboard](https://www.algolia.com/manage/applications).
-  - Go to `Algolia->Autocomplete`:  Check `Enable autocomplete`, then check `Ghiduri` and `Campanii` and hit `Save changes`. Make sure you re-index both `Ghiduri` and `Campanii`.
-  - Go to `Algolia->Search Page`: Check `Use Algolia with Instantsearch.js`. `Save changes` and hit `Re-index search page records`.
+- Go to `Algolia->Settings`: Add the API keys from your [Algolia app dashboard](https://www.algolia.com/manage/applications).
+- Go to `Algolia->Autocomplete`:  Check `Enable autocomplete`, then check `Ghiduri` and `Campanii` and hit `Save changes`. Make sure you re-index both `Ghiduri` and `Campanii`.
+- Go to `Algolia->Search Page`: Check `Use Algolia with Instantsearch.js`. `Save changes` and hit `Re-index search page records`.
 
 Now that you're set, here's the code:
 - `sage/algolia/` contains the templates for the autocomplete dropdown (`autocomplete.php`) and the search results page (`instantsearch.php`)
@@ -109,7 +106,7 @@ There are also settings in the Algolia dashboard that you can set, but they are 
 ```
 Node Sass does not yet support your current environment: Windows 64-bit with Unsupported runtime (57)
 ```
-Fix: 
+Fix:
 - If using node v8.0, bump it down (v6.0 should be fine) - https://github.com/jakearchibald/wittr/issues/20#issuecomment-342469349
 - `npm rebuild node-sass` if the above fails - https://github.com/sass/node-sass/issues/1764\
 

--- a/site/composer.json
+++ b/site/composer.json
@@ -58,7 +58,15 @@
   },
   "extra": {
     "installer-paths": {
-      "web/app/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
+      "web/app/mu-plugins/{$name}/": [
+        "type:wordpress-muplugin",
+        "wpackagist-plugin/advanced-custom-fields",
+        "wpackagist-plugin/simple-custom-post-order",
+        "wpackagist-plugin/simple-page-ordering",
+        "wpackagist-plugin/search-by-algolia-instant-relevant-results",
+        "wpackagist-plugin/cmb2",
+        "wpackagist-plugin/pirate-forms"
+      ],
       "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
       "web/app/themes/{$name}/": ["type:wordpress-theme"]
     },

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f928e9b889c07d1376ae1c8b24a2e645",
+    "content-hash": "c4f7a292ba2477e35f56886043c312eb",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Toate plugin-urile pe care le folosim sunt `must use` - asa ca le-am setat ca atare. Practic nu mai e necesara partea aia de activare manuala.

#### Test plan:
```
$> vagrant destroy
$> vagrant up
```

dar am incercat si cu 

```
$> vagrant --provision
``` 

and it's all good