### PR TITLE
fix(homepage) Show four campaigns on md screens

### DIFF
--- a/site/web/app/lib/App.php
+++ b/site/web/app/lib/App.php
@@ -8,7 +8,7 @@ final class App {
   const POST_TYPE_LINK = 'link_util';
 
   const HOMEPAGE_GUIDE_COUNT = 4;
-  const HOMEPAGE_CAMPAIGNS_COUNT = 3;
+  const HOMEPAGE_CAMPAIGNS_COUNT = 4;
   const LINK_COUNT = 7;
 
   const GUIDE_METABOX_GALLERY = 'fii_pregatit_galerie';

--- a/site/web/app/themes/sage/home.php
+++ b/site/web/app/themes/sage/home.php
@@ -111,13 +111,19 @@
   );
 
   $campaignProps = array();
+  $index = 1;
+  $is_hidden = false;
   foreach ($campaigns as $campaign) {
+    if ($index === App::HOMEPAGE_CAMPAIGNS_COUNT) {
+      $is_hidden = true;
+    }
     $campaignProps[] = array(
       'image' => $campaign->getImage(),
       'title' => $campaign->getTitle(),
       'permalink' => $campaign->getPermalink(),
       'extras' => $campaign->getExtras(),
       'date' => $campaign->getDate()->format('d.m.Y'),
+      'is_hidden' => $is_hidden,
     );
   }
 

--- a/site/web/app/themes/sage/templates/mustache/campaign_listing.mustache
+++ b/site/web/app/themes/sage/templates/mustache/campaign_listing.mustache
@@ -3,7 +3,8 @@
     <h2>Campanii</h2>
     <div class="row">
       {{# campaigns }}
-        <div class="campaign-box col-lg-4 col-md-6 col-sm-12 col-xs-12">
+        <div
+          class="campaign-box col-lg-4 col-md-6 col-sm-12 col-xs-12 {{# is_hidden }} .d-none .d-md-block .d-lg-none {{/ is_hidden }}">
           <div class="campaign-content">
             <h3>
               {{ title }}


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Campaniile arata bine doar cate 2 pe rand pe ecrane medii (tablete, telefoane cu rezolutie mai mare), therefore:

- Pe ecrane mari afiseaza un rand de 3 campanii
- Pe ecrane mici afiseaza 3 randuri de cate o campanie
- Pe ecrane medii afiseaza 2 randuri de cate 2 campanii

#### Test plan:
👀 
#### Fixes #N/A
