### PR TITLE
fix(guides) Correct icon size on guide boxes

### DIFF
--- a/site/web/app/themes/sage/assets/styles/common/_global.scss
+++ b/site/web/app/themes/sage/assets/styles/common/_global.scss
@@ -153,7 +153,6 @@ h2:after {
   border-radius: 50%;
   border: 1px solid #999;
   margin: 0 auto;
-  background-size: 60px;
   background-position: center;
   background-repeat: no-repeat;
   margin-top: 25px;


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Redimensionare corecta pentru pictogramele ghidurilor (erau prea mici, cu o redimensionare la 60px)

#### Test plan:
![fiipregatit ro just another wordpress site 2](https://user-images.githubusercontent.com/22706412/36573189-4e6f2424-1848-11e8-82d0-ad12139f6acb.png)

#### Fixes #249 
