### PR TITLE
fix(guide) Make all tabs optional

### DIFF
--- a/site/web/app/lib/Entity/Guide.php
+++ b/site/web/app/lib/Entity/Guide.php
@@ -36,33 +36,33 @@ final class Guide extends Entity {
     return $this;
   }
 
-  public function getInainteaEvenimentului(): string {
+  public function getInainteaEvenimentului(): ?string {
     return $this->inainteaEvenimentului;
   }
 
   public function setInainteaEvenimentului(
-    string $inainteaEvenimentului
+    ?string $inainteaEvenimentului
   ): Guide {
     $this->inainteaEvenimentului = $inainteaEvenimentului;
     return $this;
   }
 
-  public function getInTimpulEvenimentului(): string {
+  public function getInTimpulEvenimentului(): ?string {
     return $this->inTimpulEvenimentului;
   }
 
   public function setInTimpulEvenimentului(
-    string $inTimpulEvenimentului
+    ?string $inTimpulEvenimentului
   ): Guide {
     $this->inTimpulEvenimentului = $inTimpulEvenimentului;
     return $this;
   }
 
-  public function getDupaEveniment(): string {
+  public function getDupaEveniment(): ?string {
     return $this->dupaEveniment;
   }
 
-  public function setDupaEveniment(string $dupaEveniment): Guide {
+  public function setDupaEveniment(?string $dupaEveniment): Guide {
     $this->dupaEveniment = $dupaEveniment;
     return $this;
   }

--- a/site/web/app/themes/sage/templates/content-single-ghid.php
+++ b/site/web/app/themes/sage/templates/content-single-ghid.php
@@ -56,8 +56,17 @@
     array(
       'title' => $guide->getNume(),
       'before_content' => $guide->getInainteaEvenimentului(),
+      'is_before_single' => $guide->getInainteaEvenimentului()
+        && !$guide->getInTimpulEvenimentului()
+        && !$guide->getDupaEveniment(),
       'during_content' => $guide->getInTimpulEvenimentului(),
+      'is_during_single' => $guide->getInTimpulEvenimentului()
+        && !$guide->getInainteaEvenimentului()
+        && !$guide->getDupaEveniment(),
       'after_content' => $guide->getDupaEveniment(),
+      'is_after_single' => $guide->getDupaEveniment()
+        && !$guide->getInainteaEvenimentului()
+        && !$guide->getInTimpulEvenimentului(),
       'extra_info' => $guide->getInformatiiAditionale(),
       'video' => $guide->getVideoAjutator(),
       'photo_gallery' => $gallery,

--- a/site/web/app/themes/sage/templates/mustache/guide.mustache
+++ b/site/web/app/themes/sage/templates/mustache/guide.mustache
@@ -22,72 +22,78 @@
     <div class="row ghid-row">
       <div class="col col-lg-9 col-md-12">
         <div id="accordion">
-          <div class="card">
-            <div class="card-header" id="headingOne">
-              <h5 class="mb-0">
-                <button
-                  class="btn btn-link collapsed"
-                  data-toggle="collapse"
-                  data-target="#collapseOne"
-                  aria-expanded="true"
-                  aria-controls="collapseOne">
-                  Înainte de eveniment
-                  <i class="fa fa-chevron-down pull-right"></i>
-                </button>
-              </h5>
-            </div>
-            <div
-              id="collapseOne"
-              class="collapse">
-              <div class="card-body">
-                {{{ before_content }}}
+          {{# before_content }}
+            <div class="card">
+              <div class="card-header" id="headingOne">
+                <h5 class="mb-0">
+                  <button
+                    class="btn btn-link {{^ is_before_single }} collapsed {{/ is_before_single}}"
+                    data-toggle="collapse"
+                    data-target="#collapseOne"
+                    aria-expanded="{{# is_before_single }} true {{/ is_before_single}} {{^ is_before_single }} false {{/ is_before_single}}"
+                    aria-controls="collapseOne">
+                    Înainte de eveniment
+                    <i class="fa fa-chevron-down pull-right"></i>
+                  </button>
+                </h5>
+              </div>
+              <div
+                id="collapseOne"
+                class="collapse {{# is_before_single }} show {{/ is_before_single}}">
+                <div class="card-body">
+                  {{{ before_content }}}
+                </div>
               </div>
             </div>
-          </div>
-          <div class="card">
-            <div class="card-header" id="headingTwo">
-              <h5 class="mb-0">
-                <button
-                  class="btn btn-link collapsed"
-                  data-toggle="collapse"
-                  data-target="#collapseTwo"
-                  aria-expanded="false"
-                  aria-controls="collapseTwo">
-                  În timpul evenimentului
-                  <i class="fa fa-chevron-down pull-right"></i>
-                </button>
-              </h5>
-            </div>
-            <div
-              id="collapseTwo"
-              class="collapse">
-              <div class="card-body">
-                {{{ during_content }}}
+          {{/ before_content }}
+          {{# during_content }}
+            <div class="card">
+              <div class="card-header" id="headingTwo">
+                <h5 class="mb-0">
+                  <button
+                    class="btn btn-link {{^ is_during_single }} collapsed {{/ is_during_single}}"
+                    data-toggle="collapse"
+                    data-target="#collapseTwo"
+                    aria-expanded="{{# is_during_single }} true {{/ is_during_single}} {{^ is_during_single }} false {{/ is_during_single}}"
+                    aria-controls="collapseTwo">
+                    În timpul evenimentului
+                    <i class="fa fa-chevron-down pull-right"></i>
+                  </button>
+                </h5>
+              </div>
+              <div
+                id="collapseTwo"
+                class="collapse">
+                <div class="card-body" {{# is_during_single }} show {{/ is_during_single}}>
+                  {{{ during_content }}}
+                </div>
               </div>
             </div>
-          </div>
-          <div class="card">
-            <div class="card-header" id="headingThree">
-              <h5 class="mb-0">
-                <button
-                  class="btn btn-link collapsed"
-                  data-toggle="collapse"
-                  data-target="#collapseThree"
-                  aria-expanded="false"
-                  aria-controls="collapseThree">
-                  După eveniment
-                  <i class="fa fa-chevron-down pull-right"></i>
-                </button>
-              </h5>
-            </div>
-            <div
-              id="collapseThree"
-              class="collapse">
-              <div class="card-body">
-                {{{ after_content }}}
+          {{/ during_content }}
+          {{# after_content }}
+            <div class="card">
+              <div class="card-header" id="headingThree">
+                <h5 class="mb-0">
+                  <button
+                    class="btn btn-link {{^ is_after_single }} collapsed {{/ is_after_single}}"
+                    data-toggle="collapse"
+                    data-target="#collapseThree"
+                    aria-expanded="{{# is_after_single }} true {{/ is_after_single}} {{^ is_after_single }} false {{/ is_after_single}}"
+                    aria-controls="collapseThree">
+                    După eveniment
+                    <i class="fa fa-chevron-down pull-right"></i>
+                  </button>
+                </h5>
+              </div>
+              <div
+                id="collapseThree"
+                class="collapse">
+                <div class="card-body" {{# is_after_single }} show {{/ is_after_single}}>
+                  {{{ after_content }}}
+                </div>
               </div>
             </div>
-          </div>
+          {{/ after_content }}
           {{# has_extra_info }}
             <div class="card">
               <div class="card-header" id="headingFour">


### PR DESCRIPTION
#### Rezumat al schimbărilor:
- facut taburi `inainte`, `dupa`, `in timpul` optionale
- daca un tab nu are content, nu este afisat
- daca un singur tab are content, e deschis by default
- daca niciun tab nu are content, se afiseaza ghidul gol (!must fix)

#### Test plan:
👀 

#### Fixes #238 
