### PR TITLE
fix(guide) content not expanded. Closes #458

### DIFF
--- a/site/web/app/themes/sage/templates/mustache/guide.mustache
+++ b/site/web/app/themes/sage/templates/mustache/guide.mustache
@@ -64,7 +64,7 @@
               <div
                 id="collapseTwo"
                 class="collapse">
-                <div class="card-body" {{# is_during_single }} show {{/ is_during_single}}>
+                <div class="card-body {{# is_during_single }} show {{/ is_during_single}}">
                   {{{ during_content }}}
                 </div>
               </div>
@@ -88,7 +88,7 @@
               <div
                 id="collapseThree"
                 class="collapse">
-                <div class="card-body" {{# is_after_single }} show {{/ is_after_single}}>
+                <div class="card-body {{# is_after_single }} show {{/ is_after_single}}">
                   {{{ after_content }}}
                 </div>
               </div>


### PR DESCRIPTION
#### Rezumat al schimbărilor:
Clasa de "show" nu era pusa corect intre ghilimele.

#### Test plan:
https://fiipregatit.ro/ghid/accident-nuclear/ ar trebui sa fie deshis gata expandat pentru ca este un singur tab.
#### Fixes #458 
